### PR TITLE
RefileS3: Fix Ruby 3.4 compatibility blockers

### DIFF
--- a/lib/refile/s3.rb
+++ b/lib/refile/s3.rb
@@ -95,7 +95,7 @@ module Refile
     # @param [String] id           The id of the file
     # @return [IO]                An IO object containing the file contents
     verify_id def open(id)
-      Kernel.open(object(id).presigned_url(:get))
+      URI.open(object(id).presigned_url(:get))
     end
 
     # Return the entire contents of the uploaded file as a String.

--- a/lib/refile/s3/version.rb
+++ b/lib/refile/s3/version.rb
@@ -1,5 +1,5 @@
 module Refile
   class S3
-    VERSION = "0.2.0"
+    VERSION = "0.2.1"
   end
 end

--- a/refile-s3.gemspec
+++ b/refile-s3.gemspec
@@ -14,10 +14,9 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.1.0"
+  spec.required_ruby_version = ">= 3.1.0"
 
   spec.add_dependency "refile", "~> 0.7.0"
   spec.add_dependency "aws-sdk-s3", "~> 1.23"

--- a/spec/refile/s3_spec.rb
+++ b/spec/refile/s3_spec.rb
@@ -3,7 +3,7 @@ require "refile/s3"
 
 WebMock.allow_net_connect!
 
-config = YAML.load_file("s3.yml").map { |k, v| [k.to_sym, v] }.to_h
+config = YAML.safe_load_file("s3.yml").map { |k, v| [k.to_sym, v] }.to_h
 
 RSpec.describe Refile::S3 do
   let(:backend) { Refile::S3.new(max_size: 100, **config) }


### PR DESCRIPTION
### What does this PR do? (required)
Fixes the gem so it can be built and installed on Ruby 3.4. Removes the `spec.test_files=` gemspec assignment removed in RubyGems 3.5, replaces deprecated `Kernel.open` with `URI.open`, updates the minimum Ruby version constraint, and uses `YAML.safe_load_file` in specs.

### Link to Basecamp to-do, Trello card, New Relic or Honeybadger (required)
https://linear.app/wealthbox-crm/issue/SRE-76/refile-s3-fix-gemspec-blocker-for-ruby-34

### QA
What platforms should be included in QA?
- [ ] Desktop web
- [ ] Mobile web
- [ ] iOS
- [ ] Android
- [ ] API
- [x] N/A

### QA steps
- [x] Install the gem on a Ruby 3.4 environment: `gem install refile-s3` should succeed without errors
- [x] Verify `gem build refile-s3.gemspec` completes cleanly on Ruby 3.4 / RubyGems 3.5+
- [x] Confirm `Refile::S3#open` returns a valid IO object for a presigned S3 URL